### PR TITLE
Synchronize threads during benchmark

### DIFF
--- a/linalg-benchmark/benchmark.py
+++ b/linalg-benchmark/benchmark.py
@@ -72,7 +72,8 @@ def main():
   benchmark("PyTorch CPU", func)
 
   def func():
-    torch.svd(torch.rand((N, N)).cuda())
+    torch.svd(torch.rand((N, N)).to('cuda'))
+    torch.cuda.synchronize()
 
   benchmark("PyTorch GPU", func)
 


### PR DESCRIPTION
@yaroslavvb I believe it is required to synchronize threads during benchmarking.